### PR TITLE
Fix UIHostingController to have clear background

### DIFF
--- a/Source/Classes/Internal/OverlayContainer/OverlayContainerDynamicOverlayView.swift
+++ b/Source/Classes/Internal/OverlayContainer/OverlayContainerDynamicOverlayView.swift
@@ -65,10 +65,12 @@ struct OverlayContainerRepresentableAdaptator: UIViewControllerRepresentable {
     // MARK: - UIViewControllerRepresentable
 
     func makeCoordinator() -> OverlayContainerCoordinator {
-        OverlayContainerCoordinator(
+        let content = UIHostingController(rootView: OverlayContentHostingView())
+        content.view.backgroundColor = nil
+        return OverlayContainerCoordinator(
             layout: containerState.layout,
             animationController: animationController,
-            content: UIHostingController(rootView: OverlayContentHostingView())
+            content: content
         )
     }
 


### PR DESCRIPTION
I have fixed `UIHostingController<OverlayContentHostingView>` to have a transparent background color, which has a white as a default background color.
This allows the overlay contents to have a corner radius like below:
<img src="https://user-images.githubusercontent.com/2215080/104832195-bc45ce80-58d2-11eb-98ca-1453376a0465.png" width="375">
