### PR TITLE
Allow gestures on the background view

### DIFF
--- a/DynamicOverlay.xcodeproj/project.pbxproj
+++ b/DynamicOverlay.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		4895E51D25F2B5F100BC1048 /* BackgroundAndOverlayViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4895E51C25F2B5F100BC1048 /* BackgroundAndOverlayViewController.swift */; };
 		E7310E6E2599E0C200865422 /* DynamicOverlayContainerAnimationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7310E6D2599E0C200865422 /* DynamicOverlayContainerAnimationController.swift */; };
 		E7310E73259A102E00865422 /* DragHandleViewModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7310E72259A102E00865422 /* DragHandleViewModifier.swift */; };
 		E7310E77259A10AB00865422 /* DrivingScrollViewViewModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7310E76259A10AB00865422 /* DrivingScrollViewViewModifier.swift */; };
@@ -58,6 +59,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		4895E51C25F2B5F100BC1048 /* BackgroundAndOverlayViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BackgroundAndOverlayViewController.swift; sourceTree = "<group>"; };
 		E7310E6D2599E0C200865422 /* DynamicOverlayContainerAnimationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicOverlayContainerAnimationController.swift; sourceTree = "<group>"; };
 		E7310E72259A102E00865422 /* DragHandleViewModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DragHandleViewModifier.swift; sourceTree = "<group>"; };
 		E7310E76259A10AB00865422 /* DrivingScrollViewViewModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrivingScrollViewViewModifier.swift; sourceTree = "<group>"; };
@@ -159,6 +161,7 @@
 				E75590782578FA74001FB20C /* OverlayContentModifier.swift */,
 				E7310E7A259A117400865422 /* OverlayContainer+CoordinateSpace.swift */,
 				E7310E81259B3AC900865422 /* OverlayNotchIndexMapper.swift */,
+				4895E51C25F2B5F100BC1048 /* BackgroundAndOverlayViewController.swift */,
 			);
 			path = OverlayContainer;
 			sourceTree = "<group>";
@@ -341,6 +344,7 @@
 				E741EE672576AB7F0073FF6B /* DynamicOverlayModifier.swift in Sources */,
 				E741EEAD2577CD910073FF6B /* MagneticNotchOverlayBehaviorValue.swift in Sources */,
 				E741EE5D2576AA240073FF6B /* PassThroughContentModifier.swift in Sources */,
+				4895E51D25F2B5F100BC1048 /* BackgroundAndOverlayViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/DynamicOverlay.xcodeproj/project.pbxproj
+++ b/DynamicOverlay.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		480553B525F2E29F0063E536 /* DynamicOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 480553B425F2E29F0063E536 /* DynamicOverlay.swift */; };
 		4895E51D25F2B5F100BC1048 /* BackgroundAndOverlayViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4895E51C25F2B5F100BC1048 /* BackgroundAndOverlayViewController.swift */; };
 		E7310E6E2599E0C200865422 /* DynamicOverlayContainerAnimationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7310E6D2599E0C200865422 /* DynamicOverlayContainerAnimationController.swift */; };
 		E7310E73259A102E00865422 /* DragHandleViewModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7310E72259A102E00865422 /* DragHandleViewModifier.swift */; };
@@ -59,6 +60,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		480553B425F2E29F0063E536 /* DynamicOverlay.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DynamicOverlay.swift; sourceTree = "<group>"; };
 		4895E51C25F2B5F100BC1048 /* BackgroundAndOverlayViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BackgroundAndOverlayViewController.swift; sourceTree = "<group>"; };
 		E7310E6D2599E0C200865422 /* DynamicOverlayContainerAnimationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicOverlayContainerAnimationController.swift; sourceTree = "<group>"; };
 		E7310E72259A102E00865422 /* DragHandleViewModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DragHandleViewModifier.swift; sourceTree = "<group>"; };
@@ -121,6 +123,7 @@
 		E741EE872577AF9D0073FF6B /* Public */ = {
 			isa = PBXGroup;
 			children = (
+				480553B425F2E29F0063E536 /* DynamicOverlay.swift */,
 				E741EEA82577CC400073FF6B /* DynamicOverlayBehavior.swift */,
 				E741EE8F2577BF2A0073FF6B /* MagneticNotchOverlayBehavior.swift */,
 				E741EE662576AB7F0073FF6B /* DynamicOverlayModifier.swift */,
@@ -336,6 +339,7 @@
 				E7559086257A7152001FB20C /* DynamicOverlayDragHandle.swift in Sources */,
 				E7691590222EB15700FDEE7F /* DynamicOverlayBehaviorValue.swift in Sources */,
 				E7310E6E2599E0C200865422 /* DynamicOverlayContainerAnimationController.swift in Sources */,
+				480553B525F2E29F0063E536 /* DynamicOverlay.swift in Sources */,
 				E741EE8C2577BE200073FF6B /* Binding+CaseIterable.swift in Sources */,
 				E741EE902577BF2A0073FF6B /* MagneticNotchOverlayBehavior.swift in Sources */,
 				E7310E77259A10AB00865422 /* DrivingScrollViewViewModifier.swift in Sources */,

--- a/DynamicOverlay_Example/DynamicOverlay_Example/Classes/ViewController.swift
+++ b/DynamicOverlay_Example/DynamicOverlay_Example/Classes/ViewController.swift
@@ -28,7 +28,7 @@ struct ContentView: View {
 
     var body: some View {
         
-        OverlayContainerDynamicOverlayView(background: background, content: overlay.drivingScrollView())
+        DynamicOverlay(background: background, content: overlay.drivingScrollView())
             .dynamicOverlayBehavior(notchOverlayBehavior)
     }
     

--- a/DynamicOverlay_Example/DynamicOverlay_Example/Classes/ViewController.swift
+++ b/DynamicOverlay_Example/DynamicOverlay_Example/Classes/ViewController.swift
@@ -27,7 +27,68 @@ class ViewController: UIHostingController<ContentView> {
 struct ContentView: View {
 
     var body: some View {
-        Color.red
-            .dynamicOverlay(Color.green)
+        
+        OverlayContainerDynamicOverlayView(background: background, content: overlay.drivingScrollView())
+            .dynamicOverlayBehavior(notchOverlayBehavior)
+    }
+    
+    var background: some View {
+        
+        List {
+            
+            ForEach(0..<100) { number in
+                
+                Button(action: { print("background tap: \(number)") }) {
+                    
+                    HStack {
+                        Text("\(number)")
+                        Spacer()
+                    }
+                    .background(Color.red)
+                }
+            }
+        }
+        .listStyle(PlainListStyle())
+    }
+    
+    var overlay: some View {
+        
+        ZStack {
+                        
+            List {
+                
+                ForEach(0..<100) { number in
+                    
+                    Button(action: { print("overlay tap: \(number)") }) {
+                        HStack {
+                            Text("\(number)")
+                            Spacer()
+                        }
+                        .background(Color.green)
+                    }
+                }
+            }
+            .listStyle(PlainListStyle())
+        }
+    }
+}
+
+enum Notch: CaseIterable, Equatable {
+    case min
+    case med
+    case max
+}
+
+var notchOverlayBehavior: some DynamicOverlayBehavior {
+    
+    MagneticNotchOverlayBehavior<Notch> { notch in
+        switch notch {
+        case .max:
+            return .fractional(0.8)
+        case .med:
+            return .fractional(0.5)
+        case .min:
+            return .fractional(0.3)
+        }
     }
 }

--- a/Source/Classes/Internal/OverlayContainer/BackgroundAndOverlayViewController.swift
+++ b/Source/Classes/Internal/OverlayContainer/BackgroundAndOverlayViewController.swift
@@ -1,0 +1,77 @@
+//
+//  BackgroundAndOverlayViewController.swift
+//  DynamicOverlay
+//
+//  Created by Ivo Silva on 05.03.21.
+//  Copyright © 2021 Fabernovel. All rights reserved.
+//
+
+import SwiftUI
+import OverlayContainer
+
+class BackgroundAndOverlayContainerViewController: OverlayContainerViewController {
+    
+    private let backgroundViewController: UIViewController
+    private let backgroundView = UIView()
+    
+    init(backgroundViewController: UIViewController, style: OverlayContainerViewController.OverlayStyle) {
+        
+        self.backgroundViewController = backgroundViewController
+        
+        super.init(style: style)
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func viewDidLoad() {
+        
+        super.viewDidLoad()
+        
+        view.addSubview(backgroundView)
+        view.sendSubviewToBack(backgroundView)
+        backgroundView.pinToSuperview()
+        addChild(backgroundViewController, in: backgroundView)
+    }
+}
+
+// MARK: - UIKit extensions
+// Credits to OverlayContainer - `UIViewController+Children.swift`
+
+private extension UIViewController {
+    
+    func addChild(_ child: UIViewController, in containerView: UIView) {
+        guard containerView.isDescendant(of: view) else { return }
+        
+        addChild(child)
+        containerView.addSubview(child.view)
+        child.view.pinToSuperview()
+        child.didMove(toParent: self)
+    }
+}
+
+// Credits to OverlayContainer - `UIView+Constraints.swift`
+
+private extension UIView {
+    
+    func pinToSuperview(with insets: UIEdgeInsets = .zero, edges: UIRectEdge = .all) {
+        
+        guard let superview = superview else { return }
+        
+        translatesAutoresizingMaskIntoConstraints = false
+        
+        if edges.contains(.top) {
+            topAnchor.constraint(equalTo: superview.topAnchor, constant: insets.top).isActive = true
+        }
+        if edges.contains(.bottom) {
+            bottomAnchor.constraint(equalTo: superview.bottomAnchor, constant: -insets.bottom).isActive = true
+        }
+        if edges.contains(.left) {
+            leadingAnchor.constraint(equalTo: superview.leadingAnchor, constant: insets.left).isActive = true
+        }
+        if edges.contains(.right) {
+            trailingAnchor.constraint(equalTo: superview.trailingAnchor, constant: -insets.right).isActive = true
+        }
+    }
+}

--- a/Source/Classes/Internal/OverlayContainer/OverlayContainerDynamicOverlayView.swift
+++ b/Source/Classes/Internal/OverlayContainer/OverlayContainerDynamicOverlayView.swift
@@ -9,7 +9,7 @@
 import SwiftUI
 import OverlayContainer
 
-struct OverlayContainerDynamicOverlayView<Content: View>: View {
+public struct OverlayContainerDynamicOverlayView<Background: View, Content: View>: View {
 
     @State
     private var handleValue: DynamicOverlayDragHandle = .default
@@ -17,17 +17,25 @@ struct OverlayContainerDynamicOverlayView<Content: View>: View {
     @State
     private var searchsScrollView = false
 
+    let background: Background
     let content: Content
 
     @Environment(\.behaviorValue)
     var behavior: DynamicOverlayBehaviorValue
+    
+    public init(background: Background, content: Content) {
+        
+        self.background = background
+        self.content = content
+    }
 
-    var body: some View {
+    public var body: some View {
         GeometryReader { proxy in
             OverlayContainerRepresentableAdaptator(
                 searchsScrollView: searchsScrollView,
                 handleValue: handleValue,
-                behavior: behavior
+                behavior: behavior,
+                background: background
             )
             .passThroughContent()
             .overlayContent(content)
@@ -43,11 +51,12 @@ struct OverlayContainerDynamicOverlayView<Content: View>: View {
     }
 }
 
-struct OverlayContainerRepresentableAdaptator: UIViewControllerRepresentable {
+struct OverlayContainerRepresentableAdaptator<Background: View>: UIViewControllerRepresentable {
 
     let searchsScrollView: Bool
     let handleValue: DynamicOverlayDragHandle
     let behavior: DynamicOverlayBehaviorValue
+    let background: Background
 
     private var animationController: DynamicOverlayContainerAnimationController {
         DynamicOverlayContainerAnimationController()
@@ -75,7 +84,11 @@ struct OverlayContainerRepresentableAdaptator: UIViewControllerRepresentable {
     }
 
     func makeUIViewController(context: Context) -> OverlayContainerViewController {
-        let controller = OverlayContainerViewController(style: .flexibleHeight)
+        let backgroundController = UIHostingController(rootView: background)
+        let controller = BackgroundAndOverlayContainerViewController(
+            backgroundViewController: backgroundController,
+            style: .flexibleHeight
+        )
         controller.delegate = context.coordinator
         return controller
     }

--- a/Source/Classes/Internal/OverlayContainer/OverlayContainerDynamicOverlayView.swift
+++ b/Source/Classes/Internal/OverlayContainer/OverlayContainerDynamicOverlayView.swift
@@ -9,7 +9,7 @@
 import SwiftUI
 import OverlayContainer
 
-public struct OverlayContainerDynamicOverlayView<Background: View, Content: View>: View {
+struct OverlayContainerDynamicOverlayView<Background: View, Content: View>: View {
 
     @State
     private var handleValue: DynamicOverlayDragHandle = .default
@@ -23,13 +23,13 @@ public struct OverlayContainerDynamicOverlayView<Background: View, Content: View
     @Environment(\.behaviorValue)
     var behavior: DynamicOverlayBehaviorValue
     
-    public init(background: Background, content: Content) {
+    init(background: Background, content: Content) {
         
         self.background = background
         self.content = content
     }
 
-    public var body: some View {
+    var body: some View {
         GeometryReader { proxy in
             OverlayContainerRepresentableAdaptator(
                 searchsScrollView: searchsScrollView,

--- a/Source/Classes/Public/DynamicOverlay.swift
+++ b/Source/Classes/Public/DynamicOverlay.swift
@@ -1,0 +1,18 @@
+import SwiftUI
+
+public struct DynamicOverlay<Background: View, Content: View>: View {
+    
+    let background: Background
+    let content: Content
+    
+    public init(background: Background, content: Content) {
+        
+        self.background = background
+        self.content = content
+    }
+    
+    public var body: some View {
+        
+        OverlayContainerDynamicOverlayView(background: background, content: content)
+    }
+}

--- a/Source/Classes/Public/DynamicOverlayModifier.swift
+++ b/Source/Classes/Public/DynamicOverlayModifier.swift
@@ -10,15 +10,6 @@ import SwiftUI
 
 public extension View {
 
-    /// Adds a dynamic overlay above this view.
-    ///
-    /// - parameter content: the content of the overlay.
-    ///
-    /// - returns:A view with a dynamic overlay added above this view.
-    func dynamicOverlay<Content: View>(_ content: Content) -> some View {
-        modifier(AddDynamicOverlayModifier(overlay: content))
-    }
-
     /// Sets the overlay behavior for dynamic overlays within this view.
     ///
     /// - parameter behavior: the behavior to apply.
@@ -28,21 +19,6 @@ public extension View {
     /// This modifier affects the given view, as well as that view’s descendant views. It has no effect outside the view hierarchy on which you call it.
     func dynamicOverlayBehavior<Behavior: DynamicOverlayBehavior>(_ behavior: Behavior) -> some View {
         modifier(behavior.makeModifier())
-    }
-}
-
-public struct AddDynamicOverlayModifier<Overlay: View>: ViewModifier {
-
-    let overlay: Overlay
-
-    // MARK: - ViewModifier
-
-    public func body(content: Content) -> some View {
-        content.overlay(
-            OverlayContainerDynamicOverlayView(
-                content: overlay
-            )
-        )
     }
 }
 


### PR DESCRIPTION
Hello 👋 
First of all, thanks a lot for creating and maintaining this library! 🙏 

**Problem**

The issue is described in #2 and #3.
When having an overlay view, we are not able to tap or drag the background view.

**Solution**

Picking up on @matthewcheok's investigation, I created an extra view controller to wrap both the background and overlay views.
This way, SwiftUI does not generate the view (between the background and overlay) that prevents gestures from getting to the background view.

In the video below we can see the proposed solution working.
It's composed of a view that has one `List` as the background and another one as the overlay. The video shows that it is possible with this solution to tap and drag the list in the background view as well as maintaining the current overlay behavior.

https://user-images.githubusercontent.com/4477378/110162963-b6a73800-7def-11eb-93b5-014790818efd.mov

**Description**

- Create `BackgroundAndOverlayContainerViewController` to add the background view to the overlay container
- Change `OverlayContainerDynamicOverlayView` to accept the background view
- Remove `dynamicOverlay` modifier to make user explicitly inject the background view
- Update example app with more complete use case featuring `List` elements and `Notch` behaviors

If this approach seems sensible to you, I can maybe improve `OverlayContainerDynamicOverlayView`'s naming (or wrap it in a different SwiftUI view) to make it more usable from the caller's perspective and place in the `Public` folder.

EDIT: Added `DynamicOverlay` public wrapper SwiftUI component.

Let me know if you have other suggestions as well 😃 